### PR TITLE
Fix Incomplete Interoperability With Quickshulker

### DIFF
--- a/src/main/java/atonkish/reinfshulker/block/ReinforcedShulkerBoxBlock.java
+++ b/src/main/java/atonkish/reinfshulker/block/ReinforcedShulkerBoxBlock.java
@@ -1,5 +1,6 @@
 package atonkish.reinfshulker.block;
 
+import net.kyrptonaught.shulkerutils.UpgradableShulker;
 import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
@@ -27,7 +28,7 @@ import atonkish.reinfshulker.block.entity.ModBlockEntityType;
 import atonkish.reinfshulker.block.entity.ReinforcedShulkerBoxBlockEntity;
 import atonkish.reinfshulker.stat.ModStats;
 
-public class ReinforcedShulkerBoxBlock extends ShulkerBoxBlock {
+public class ReinforcedShulkerBoxBlock extends ShulkerBoxBlock implements UpgradableShulker {
     private final ReinforcingMaterial material;
 
     public ReinforcedShulkerBoxBlock(ReinforcingMaterial material, @Nullable DyeColor color,
@@ -93,5 +94,10 @@ public class ReinforcedShulkerBoxBlock extends ShulkerBoxBlock {
 
     public static ItemStack getItemStack(ReinforcingMaterial material, @Nullable DyeColor color) {
         return new ItemStack(get(material, color));
+    }
+
+    @Override
+    public int getInventorySize() {
+        return getMaterial().getSize();
     }
 }


### PR DESCRIPTION
Before this change, the bundling feature of quickshulker deleted items after the 27th slot because [the default behavior depends on `UpgradableShulker`](https://github.com/kyrptonaught/shulkerutils/blob/1.18/src/main/java/net/kyrptonaught/shulkerutils/ShulkerUtils.java#L36) and assumes all shulker boxes are 27 slot inventories.

This PR implements that interface and fixes that bundling issue.